### PR TITLE
Port engine to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.17)
 project(hexarena_backend CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 include_directories(.)
 include_directories(engine)
 
-add_executable(hexarena_backend main.cpp)
+add_executable(hexarena_backend main.cpp engine/user.cpp engine/component.h engine/utils.h engine/engine.cpp)

--- a/docs/bodypart-interactions.md
+++ b/docs/bodypart-interactions.md
@@ -1,0 +1,33 @@
+# Interactions between bodyparts
+
+When parts of different kinds collide with each other various things happen:
+
+### CELL:
+- CELL - nothing
+- SPIKE - cell gets damaged
+- SHIELD - nothing
+- BOUNCE - cell gets pushed back
+
+### SPIKE:
+- CELL - cell gets damaged
+- SPIKE - both spikes get damaged. 
+  But also in the current implementation this can't happen, they'd cross
+  each other and collide with the cells they are attached to.
+- SHIELD - nothing
+- BOUNCE - bounce is deflated, spike gets pushed back strongly
+
+### SHIELD:
+- CELL - nothing
+- SPIKE - nothing
+- SHIELD - nothing
+- BOUNCE - shield gets pushed back
+
+### BOUNCE:
+- CELL - cell gets pushed back
+- SPIKE - bounce is deflated, spike gets pushed back strongly
+- SHIELD - shield gets pushed back
+- BOUNCE - undecided.
+  - bounce off normally
+  - bounce off strongly but do not deflate
+  - nothing, bounce cancel each other out
+  - something weird, like transferring momentum so both users travel together

--- a/engine/component.h
+++ b/engine/component.h
@@ -1,0 +1,25 @@
+#ifndef HEXARENA_BACKEND_COMPONENT_H
+#define HEXARENA_BACKEND_COMPONENT_H
+
+#include "constants.h"
+
+struct Component{
+    BODYPART_TYPE type;
+    /// order is: top-right, top, top-left, bottom-left, bottom, bottom-right. Counterclockwise starting at the x axis
+    int faces[6];
+    int health;
+    bool dead;
+    std::tuple<int, int, int> coords;
+
+    // bounce
+    int inflated;
+
+    [[nodiscard]] bool is_working() const {
+        return inflated >= MAX_INFLATE;
+    }
+
+    // bounce/spike/shield
+    int body;
+};
+
+#endif //HEXARENA_BACKEND_COMPONENT_H

--- a/engine/constants.h
+++ b/engine/constants.h
@@ -2,37 +2,53 @@
 #define HEXARENA_BACKEND_CONSTANTS_H
 
 #include <map>
+#include <cmath>
 
 enum BODYPART_TYPE {
+    NONE = 0,
     CELL,
     SPIKE,
     SHIELD,
     BOUNCE
 };
 
-std::map<BODYPART_TYPE, int> BODYPART_COST = {{CELL, 20},
+const std::map<BODYPART_TYPE, int> BODYPART_COST = {{CELL, 20},
                                                      {SPIKE, 15},
                                                      {SHIELD, 10},
                                                      {BOUNCE, 15}};
+const double FACE_TO_ANGLE[6] = {M_PI/6, M_PI*3/6, M_PI*5/6, M_PI*7/6, M_PI*9/6, M_PI*11/6};
 
-#define MAX_HEALTH 100
 #define MAX_INFLATE 100
 #define INFLATE_RATE 2
+#define BOUNCE_MOMENTUM 3
+#define BOUNCE_MOMENTUM_SELF 0
+#define BOUNCE_POPPED_MULTIPLIER 2
+#define MAX_HEALTH 100
 #define REGEN_RATE 1
 #define SPIKE_DMG 3
 
-enum ACTION {
-    MOVE,
-    DESTROY,
-    COLLIDE
-};
-
 #define CHEATS_ENABLED 1
 
-#define RESOURCE_SIZE_STEP 10
+#define RESOURCE_SIZE_STEP 0.1
 #define RESOURCE_SIZE_MIN 5
 #define RESOURCE_SIZE_MAX 20
 
 #define MINING_RATE 1
+#define SPIKE_MINING_MULTIPLIER 2
+
+#define MOMENTUM_GAIN_PER_TICK 1
+#define MOMENTUM_MULTIPLIER_PER_TICK 0.8
+/// Maximum amount we can move an entity without checking for collisions. Collisions are very expensive so we want
+/// to increase this number as much as possible.
+#define MAX_SAFE_MOVEMENT 2
+
+#define MOMENTUM_TRANSFER_ON_COLLISION 0.5
+
+#define TICK_RATE 30
+#define WORLD_WIDTH 3000
+#define WORLD_HEIGHT 3000
+#define RESOURCE_DENSITY 3
+#define NATURAL_RESOURCE_AMOUNT 5
+#define MAX_ROTATION_ITERATIONS 100
 
 #endif //HEXARENA_BACKEND_CONSTANTS_H

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -1,0 +1,235 @@
+#include "engine.h"
+#include "utils.h"
+
+#include <cmath>
+#include <random>
+#include <iostream>
+#include <thread>
+
+Engine::Engine() {
+    this->tick_num = 0;
+    this->next_user_id = 0;
+    this->running = true;
+    this->runner = std::thread(&Engine::run, this);
+}
+
+int Engine::add_user(double x, double y) {
+    int id = next_user_id++;
+    return this->users.insert({id++, {id, x, y, [&](int amt, double x, double y){
+        this->drop(amt, x, y);
+    }}}).first->first;
+}
+
+void Engine::move(int id, double angle) {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    User &user = this->users.at(id);
+    if (user.moved) return;
+    user.moved = true;
+    user.momentum_x += std::cos(angle) * MOMENTUM_GAIN_PER_TICK;
+    user.momentum_y += std::sin(angle) * MOMENTUM_GAIN_PER_TICK;
+}
+
+void Engine::rotate(int id, double angle) {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    User &user = this->users.at(id);
+    if (user.rotated) return;
+    user.rotated = true;
+
+    double size = user.get_size();
+    for (int iter = 0; user.rotation != angle && iter < MAX_ROTATION_ITERATIONS; iter++) {
+        double direction = angle > user.rotation && angle < user.rotation + M_PI ? 1 : -1;
+
+        double delta = MAX_SAFE_MOVEMENT / size * direction;
+        double new_angle = user.rotation + delta;
+
+        if ((user.rotation < angle && angle < new_angle) || (user.rotation > angle && angle > new_angle)) {
+            new_angle = angle;
+        }
+
+        double old_angle = user.rotation;
+        user.rotation = new_angle;
+        bool blocked = false;
+        // user2 is a copy, do not attempt to modify it or pass it anywhere as a reference
+        for (auto& [id2, user2] : this->users) {
+            if (id == id2) continue;
+            blocked = blocked || user.collide_with_user(this->users.at(id2));
+        }
+
+        if (blocked) {
+            user.rotation = old_angle;
+            break;
+        }
+    }
+}
+
+int Engine::create() {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    std::uniform_real_distribution<double> uniform_width(0, WORLD_WIDTH);
+    std::uniform_real_distribution<double> uniform_height(0, WORLD_HEIGHT);
+    double x, y;
+
+    bool has_space;
+    int iter = 0;
+    do {
+        x = uniform_width(gen);
+        y = uniform_height(gen);
+        has_space = true;
+        for (auto [id, user] : users) {
+            if (distance(x, y, user.x, user.y) < user.get_size() + CELL_INNER_RADIUS * 2) {
+                has_space = false;
+            }
+        }
+    } while (!has_space && iter++ < 20);
+
+    if (!has_space) {
+        std::cerr << "no space for new user" << std::endl;
+        return -1;
+    }
+
+    return this->add_user(x, y);
+}
+
+void Engine::remove(int id) {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    User &user = this->users.at(id);
+    user.shrink(0);
+    user.destroyed = true;
+    if (user.resources > 0) {
+        this->resources.push_back({user.x, user.y, user.resources / 2});
+    }
+    for (auto observer : user.observers) // TODO: discuss how to notify observers of destruction;
+    this->users.erase(id);
+}
+
+int Engine::attach(int id, BODYPART_TYPE type, int part, int face) {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    if (!this->users.contains(id)) return -3;
+    User &user = this->users.at(id);
+    if (user.resources < BODYPART_COST.at(type)) return -7;
+
+    int ret = user.grow(part, face, type);
+    if (ret == 0) user.resources -= BODYPART_COST.at(type);
+    return ret;
+}
+
+int Engine::detach(int id, int part) {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    if (!this->users.contains(id)) return -3;
+    User &user = this->users.at(id);
+    if (user.next_component > part || user.components[part].type == NONE) return -2;
+
+    return user.shrink(part);
+}
+
+const User& Engine::user(int id) {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    return this->users.at(id);
+}
+const User& Engine::info(int id) {
+    return this->user(id);
+}
+
+void Engine::observe(void (*cb)(const std::vector<Resource> &, const std::map<int, User> &)) {
+    this->observers.push_back(cb);
+}
+void Engine::register_global(void (*cb)(const std::vector<Resource> &, const std::map<int, User> &)) {
+    this->observe(cb);
+}
+
+void Engine::observe(int user, void (*cb)(const User &)) {
+    this->users.at(user).observers.push_back(cb);
+}
+
+void Engine::drop(int amt, double x, double y) {
+    this->resources.push_back({x, y, amt});
+}
+
+void Engine::tick() {
+    std::lock_guard<std::mutex> guard(this->mutex);
+    this->tick_num++;
+
+    if (this->resources.size() < RESOURCE_DENSITY * WORLD_WIDTH * WORLD_HEIGHT / (1024*1024)) {
+        std::uniform_real_distribution<double> uniform_width(0, WORLD_WIDTH);
+        std::uniform_real_distribution<double> uniform_height(0, WORLD_HEIGHT);
+        this->resources.push_back({uniform_width(gen), uniform_height(gen), NATURAL_RESOURCE_AMOUNT});
+    }
+
+    for (auto [id, _] : this->users) {
+        User &user = this->users.at(id);
+        user.tick_reset();
+        user.tick_parts();
+
+        double dx = user.momentum_x;
+        double dy = user.momentum_y;
+        while (dx > 0 || dy > 0) {
+            double step_x = dx, step_y = dy;
+
+            double len = distance(0, 0, dx, dy);
+            if (len > MAX_SAFE_MOVEMENT) {
+                double frac = MAX_SAFE_MOVEMENT / len;
+                step_x = frac * dx;
+                step_y = frac * dy;
+            }
+            dx -= step_x;
+            dy -= step_y;
+
+            user.x += step_x;
+            user.y += step_y;
+            user.momentum_x *= MOMENTUM_MULTIPLIER_PER_TICK;
+            user.momentum_y *= MOMENTUM_MULTIPLIER_PER_TICK;
+
+            bool blocked = false;
+            for (auto [id2, _2] : this->users) {
+                if (id == id2) continue;
+                if (user.collide_with_user(this->users.at(id2))) blocked = true;
+            }
+
+            for (Resource &res : this->resources) {
+                if (user.collide_with_resource(res)) blocked = true;
+            }
+
+            if (blocked) {
+                user.x -= step_x;
+                user.y -= step_y;
+                break;
+            }
+        }
+
+        if (user.y > WORLD_HEIGHT) user.y = WORLD_HEIGHT;
+        if (user.y < 0) user.y = 0;
+        if (user.x > WORLD_WIDTH) user.x = WORLD_WIDTH;
+        if (user.x < 0) user.x = 0;
+    }
+
+    std::erase_if(this->resources, [](const Resource& res){
+        return res.amt <= 0;
+    });
+
+    std::erase_if(this->users, [](const User &user){
+        // TODO: observers need to be notified of death.
+        return user.destroyed;
+    });
+
+    for (auto observer : this->observers) {
+        observer(this->resources, this->users);
+    }
+    for (auto [id, user] : this->users) {
+        for (auto observer : user.observers) {
+            observer(user);
+        }
+    }
+}
+void Engine::run() {
+    std::chrono::time_point<std::chrono::steady_clock> last_tick = std::chrono::steady_clock::now();
+    while (this->running) {
+        uint time_between_ticks = 1000 / TICK_RATE;
+        std::this_thread::sleep_until(last_tick + std::chrono::milliseconds(time_between_ticks));
+        last_tick = std::chrono::steady_clock::now();
+        tick();
+    }
+}
+
+Engine::~Engine() {
+    this->running = false;
+    this->runner.join();
+}

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -1,14 +1,46 @@
 #ifndef HEXARENA_BACKEND_ENGINE_H
 #define HEXARENA_BACKEND_ENGINE_H
 
+#include <random>
+#include <thread>
 #include "constants.h"
+#include "user.h"
+#include "utils.h"
+
 
 class Engine {
+private:
+    std::random_device r;
+    std::mt19937 gen{r()};
+
+    long tick_num;
+    std::map<int, User> users;
+    int next_user_id;
+    std::vector<Resource> resources;
+    void tick();
+    void run();
+    int add_user(double x, double y);
+    bool running;
+    std::thread runner;
+    std::mutex mutex;
+    std::vector<void (*)(const std::vector<Resource>&, const std::map<int, User>&)> observers;
 
 public:
-    void init() {
-
-    }
+    Engine();
+    ~Engine();
+    void move(int id, double angle);
+    void rotate(int id, double angle);
+    int create();
+    void remove(int id);
+    int attach(int id, BODYPART_TYPE type, int part, int face);
+    int detach(int id, int part);
+    const User & user(int id);
+    [[deprecated("renamed to user()")]] const User & info(int id);
+    void observe(void (*cb)(const std::vector<Resource>&, const std::map<int, User>&));
+    [[deprecated("renamed to observe()")]]
+    void register_global(void (*cb)(const std::vector<Resource>&, const std::map<int, User>&));
+    void observe(int user, void (*cb)(const User &));
+    void drop(int amt, double x, double y);
 };
 
 #endif //HEXARENA_BACKEND_ENGINE_H

--- a/engine/user.cpp
+++ b/engine/user.cpp
@@ -1,0 +1,636 @@
+#include <iostream>
+#include <cmath>
+#include <utility>
+
+#include "user.h"
+
+User::User(int id, double x, double y, std::function<void(int, double, double)> drop) {
+    this->id = id;
+    this->x = x;
+    this->y = y;
+    this->momentum_x = 0;
+    this->momentum_y = 0;
+    this->rotation = 0;
+    this->resources = 0;
+    this->kills = 0;
+    this->components = new Component[16];
+    this->components_size = 16;
+    for (Component* it = this->components; it < this->components + this->components_size; it++) {
+        it->type = NONE;
+    }
+    this->next_component = 0;
+    this->destroyed = false;
+    this->moved = false;
+    this->rotated = false;
+    this->size = CELL_INNER_RADIUS * 2;
+    this->drop = std::move(drop);
+}
+
+void User::tick_reset() {
+    moved = false;
+    rotated = false;
+}
+
+void User::tick_parts() const {
+    for (Component* it = this->components; it < this->components + this->components_size; it++) {
+        switch(it->type) {
+            case CELL:
+                it->health += REGEN_RATE;
+                if (it->health > MAX_HEALTH) it->health = MAX_HEALTH;
+                break;
+            case BOUNCE:
+                it->inflated += INFLATE_RATE;
+                if (it->inflated >= MAX_INFLATE) it->inflated = MAX_INFLATE;
+            case SPIKE: // NOLINT(bugprone-branch-clone)
+            case SHIELD:
+                break;
+            case NONE:
+                // skip - this cell of the array is empty
+                break;
+        }
+    }
+}
+
+
+double distance(User &a, User &b) {
+    return distance(a.x, a.y, b.x, b.y);
+}
+std::pair<double, double> rel_pos(double x, double y, int up, int fwd, int bwd) {
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "UnusedValue"
+    y -= fwd * CELL_INNER_RADIUS * 2;
+    bwd += fwd;
+    fwd -= fwd;
+
+    // now up and bwd are opposites by the up+fwd+bwd=0 equality
+    y -= CELL_INNER_RADIUS * up;
+    x += CELL_INNER_RADIUS + 20 * up;
+
+    return {x, y};
+#pragma clang diagnostic pop
+}
+
+/**
+ * Attaches a new part to the user. Specifying an invalid face (< 0 || > 6) is undefined behavior
+ * @param part The id of the component at which the new component is attached
+ * @param face The face on the component at which the new component is attached
+ * @param type The type of the component to attach
+ * @return 0 on success, error code on failure:
+ *   - -1 - asked to attach a component to a component that is not a cell
+ *   - -2 - asked to attach a component on a face that is not free
+ *   - -3 - reserved
+ *   - -4 - the given face of the given part is free but another cell occupies the space in front of it.
+ *          This should never happen, but is controlled as a sanity check.
+ *   - -5 - asked to attach a component to a component that does not exist
+ *   - -6 - trying to build a cell on a space that is already occupied by a (small) component
+ *   - -7 - reserved
+ *   - -8 - trying to build a component of type NONE
+ */
+int User::grow(int part, int face, BODYPART_TYPE type)  {
+    if (type == NONE) return -8;
+    if (part < 0 || part >= next_component || this->components[part].type == NONE) return -5;
+    if (this->components[part].type != CELL) return -1;
+    if (this->components[part].faces[face] != -1) return -2;
+
+    int newcoords[3] = {
+            std::get<0>(this->components[part].coords),
+            std::get<1>(this->components[part].coords),
+            std::get<2>(this->components[part].coords)
+    };
+    if (face == 2 || face == 3) {
+        newcoords[0] += 1;
+    }
+    if (face == 5 || face == 0) {
+        newcoords[0] -= 1;
+    }
+    if (face == 0 || face == 1) {
+        newcoords[1] += 1;
+    }
+    if (face == 3 || face == 4) {
+        newcoords[1] -= 1;
+    }
+    if (face == 4 || face == 5) {
+        newcoords[2] += 1;
+    }
+    if (face == 1 || face == 2) {
+        newcoords[2] -= 1;
+    }
+
+    // if everything else works this should be impossible. Once we're convinced it is so we can remove this check
+    auto iter = std::find_if(this->components, (this->components + this->next_component),
+                 [&](Component c){
+        return c.type == CELL
+        && std::get<0>(c.coords) == newcoords[0]
+        && std::get<1>(c.coords) == newcoords[1]
+        && std::get<2>(c.coords) == newcoords[2];
+    });
+    if (iter < this->components + this->next_component) {
+        std::cerr << "inconsistent components: face free but space occupied" << std::endl;
+        return -4;
+    }
+
+    // check that no other bodypart (particularly spikes/shields/bouncers) occupies the space we're trying to fill
+    if (type == CELL) {
+        iter = std::find_if(this->components, this->components + this->next_component,
+                  [&](Component c){
+                      if (c.type != CELL) return false;
+                      // returns true if there's a cell adjacent to our target position with the face pointing to us
+                      // occupied. That would mean there's a component (e.g. a spike) where we're trying to build.
+                      return std::get<0>(c.coords) == newcoords[0] - 1
+                      && std::get<1>(c.coords) == newcoords[1] + 1
+                      && std::get<2>(c.coords) == newcoords[2]
+                      && c.faces[5] != -1
+                      ||
+                      std::get<0>(c.coords) == newcoords[0]
+                      && std::get<1>(c.coords) == newcoords[1] + 1
+                      && std::get<2>(c.coords) == newcoords[2] - 1
+                      && c.faces[4] != -1
+                      ||
+                      std::get<0>(c.coords) == newcoords[0] + 1
+                      && std::get<1>(c.coords) == newcoords[1]
+                      && std::get<2>(c.coords) == newcoords[2] - 1
+                      && c.faces[3] != -1
+                      ||
+                      std::get<0>(c.coords) == newcoords[0] + 1
+                      && std::get<1>(c.coords) == newcoords[1] - 1
+                      && std::get<2>(c.coords) == newcoords[2]
+                      && c.faces[2] != -1
+                      ||
+                      std::get<0>(c.coords) == newcoords[0]
+                      && std::get<1>(c.coords) == newcoords[1] - 1
+                      && std::get<2>(c.coords) == newcoords[2] + 1
+                      && c.faces[1] != -1
+                      ||
+                      std::get<0>(c.coords) == newcoords[0] - 1
+                      && std::get<1>(c.coords) == newcoords[1]
+                      && std::get<2>(c.coords) == newcoords[2] + 1
+                      && c.faces[0] != -1;
+        });
+        if (iter < this->components + this->next_component) return -6;
+    }
+
+    if (next_component == components_size) {
+        components_size *= 2;
+        auto* tmp = new Component[components_size];
+        for (int i = 0; i < this->next_component; i++) {
+            tmp[i] = this->components[i];
+        }
+        delete this->components;
+        this->components = tmp;
+    }
+
+    int i = this->next_component++;
+    this->components[i].type = type;
+
+    switch (type) {
+        case BOUNCE:
+            this->components[i].inflated = MAX_INFLATE;
+        case SPIKE:
+        case SHIELD:
+            this->components[i].body = part;
+            break;
+        case CELL:
+            this->components[i].health = MAX_HEALTH;
+            this->components[i].dead = false;
+            for (int & _face : this->components[i].faces) _face = -1;
+            this->components[i].coords = {newcoords[0], newcoords[1], newcoords[2]};
+
+            // set the faces for all adjacent cells
+            for (int j = 0; j < this->next_component - 1; j++) {
+                Component* c = this->components + j;
+                if (c->type != CELL) continue;
+                if (c->coords == (std::tuple<int, int, int>){newcoords[0]-1, newcoords[1]+1, newcoords[2]}) {
+                    this->components[i].faces[2] = j;
+                    c->faces[5] = i;
+                } else if (c->coords == (std::tuple<int, int, int>){newcoords[0], newcoords[1]+1, newcoords[2]-1}) {
+                    this->components[i].faces[1] = j;
+                    c->faces[4] = i;
+                } else if (c->coords == (std::tuple<int, int, int>){newcoords[0]+1, newcoords[1], newcoords[2]-1}) {
+                    this->components[i].faces[0] = j;
+                    c->faces[3] = i;
+                } else if (c->coords == (std::tuple<int, int, int>){newcoords[0]+1, newcoords[1]-1, newcoords[2]}) {
+                    this->components[i].faces[5] = j;
+                    c->faces[2] = i;
+                } else if (c->coords == (std::tuple<int, int, int>){newcoords[0], newcoords[1]-1, newcoords[2]+1}) {
+                    this->components[i].faces[4] = j;
+                    c->faces[1] = i;
+                } else if (c->coords == (std::tuple<int, int, int>){newcoords[0]-1, newcoords[1], newcoords[2]+1}) {
+                    this->components[i].faces[3] = j;
+                    c->faces[0] = i;
+                }
+            }
+            break;
+        case NONE:
+            // cannot occur, we made sure type is not none earlier
+            break;
+    }
+    this->components[part].faces[face] = this->next_component - 1;
+    this->compute_size();
+    return 0;
+}
+
+/**
+ * Damages the given component by the given amount.
+ * @param part the component to damage. Must be of type cell.
+ * @param amt the amount of damage taken.
+ * @return true iff the component was destroyed
+ */
+bool User::damage(int part, int amt) {
+    Component* component = this->components + part;
+
+    if (component->type == SHIELD) return false;
+    if (component->type == SPIKE || component->type == BOUNCE) component = this->components + component->body;
+    // now component has to point to a cell
+    component->health -= amt;
+    if (component->health <= 0) {
+        // cast is safe - we will never have more than MAX_INT components
+        return this->shrink(static_cast<int>(std::distance(this->components, components)));
+    }
+    return false;
+}
+
+/**
+ * Destroys the given component of this user.
+ * @param part The id (index in array) of the component to destroy
+ * @return true iff this shrinkage caused user death
+ */
+bool User::shrink(int part) {
+    if (part == 0) {
+        if (this->components[0].dead) return false;
+        this->components[0].dead = true;
+        if (!this->destroyed) {
+            this->destroyed = true;
+            if (this->resources > 0) {
+                this->drop(this->resources/2, this->x, this->y);
+            }
+        }
+        for (int neighbor : this->components[0].faces) {
+            if (neighbor == -1) continue;
+            this->shrink(neighbor);
+        }
+        return true;
+    }
+    if (this->components[part].type == NONE) return false;
+    if (this->components[part].type == CELL) {
+        auto [x, y, _] = this->get_hitbox(part);
+        this->drop(BODYPART_COST.at(CELL)/2, x, y);
+    }
+    this->components->type = NONE;
+    for (int i = 0; i < this->next_component; i++) {
+        if (this->components[i].type != CELL) continue;
+        for (int &face : this->components[i].faces) {
+            if (face == part) face = -1;
+        }
+    }
+    std::set<int> connected;
+    this->find_connected(0, connected);
+    for (int i = 0; i < this->next_component; i++) {
+        if (connected.contains(i)) continue;
+        if (this->components[i].type == CELL) {
+            auto [x, y, _] = this->get_hitbox(i);
+            this->drop(BODYPART_COST.at(CELL)/2, x, y);
+        }
+        this->components[i].type = NONE;
+    }
+    this->compute_size();
+    return false;
+}
+
+void User::find_connected(int node, std::set<int> &set) {
+    if (set.contains(node)) return;
+    set.insert(node);
+    if (this->components[node].type != CELL) return;
+    for (int face : this->components[node].faces) {
+        if (face == -1) continue;
+        this->find_connected(face, set);
+    }
+}
+
+/**
+ * Given the id (index in array) of a component of this user, returns its current hitbox.
+ * @param component The id of the component. Index into this->components. Must be CELL or SPIKE
+ * @return a tuple (x, y, size) where x and y are the coordinates of the center of the hitbox and size is its radius.
+ *         All hitboxes are circular
+ */
+std::tuple<double, double, int> User::get_hitbox(int component) const {
+    double pos_x, pos_y;
+    int size;
+    if (this->components[component].type == CELL) {
+        auto [pos_x_tmp, pos_y_tmp] = rel_pos(this->x, this->y,
+                                              std::get<0>(this->components[component].coords),
+                                              std::get<1>(this->components[component].coords),
+                                              std::get<2>(this->components[component].coords));
+        pos_x = pos_x_tmp;
+        pos_y = pos_y_tmp;
+        size = CELL_INNER_RADIUS;
+    } else {
+        int parent = this->components[component].body;
+        auto [parent_x, parent_y] = rel_pos(this->x, this->y,
+                                            std::get<0>(this->components[parent].coords),
+                                            std::get<1>(this->components[parent].coords),
+                                            std::get<2>(this->components[parent].coords));
+        int face = -1;
+        for (int i = 0; i < 6; i++) {
+            if (this->components[parent].faces[i] == component) {
+                face = i;
+                break;
+            }
+        }
+        int mult_x, mult_y;
+        switch (face) {
+            case 0:
+                mult_x = -24;
+                mult_y = -14;
+                break;
+            case 1:
+                mult_x = 0;
+                mult_y = -28;
+                break;
+            case 2:
+                mult_x = 24;
+                mult_y = -14;
+                break;
+            case 3:
+                mult_x = 24;
+                mult_y = 14;
+                break;
+            case 4:
+                mult_x = 0;
+                mult_y = 28;
+                break;
+            case 5:
+                mult_x = -24;
+                mult_y = 14;
+                break;
+            default:
+                std::cerr << "Malformed body: parent (" << parent << ") not adjacent to child (" << component << ")" << std::endl;
+                throw std::invalid_argument("Malformed body: parent not adjacent to child");
+        }
+
+        switch (this->components[component].type) {
+            // We do not use hitboxes for shield and bounce. The only things that need hitbox detection are spikes and cells
+//            case BOUNCE:
+//                pos_x = parent_x + (10./14) * mult_x;
+//                pos_y = parent_y + (10./14) * mult_y;
+//                size = 18;
+//                break;
+//            case SHIELD:
+//                pos_x = parent_x + (10./14) * mult_x;
+//                pos_y = parent_y + (10./14) * mult_y;
+//                size = 18;
+//                break;
+            case SPIKE:
+                pos_x = parent_x + 2 * mult_x;
+                pos_y = parent_y + 2 * mult_y;
+                size = 0;
+                break;
+            default:
+                throw std::invalid_argument("hitbox can only be retrieved on CELL and SPIKE");
+        }
+    }
+    pos_x = std::cos(this->rotation) * (pos_x - this->x) - std::sin(this->rotation) * (pos_y - this->y) + this->x;
+    pos_y = std::sin(this->rotation) * (pos_x - this->x) + std::cos(this->rotation) * (pos_y - this->y) + this->y;
+    return {pos_x, pos_y, size};
+}
+
+std::pair<double, double> User::get_direction_normalised(int component, User &to, int component2) const {
+    auto [pos_x, pos_y, _] = this->get_hitbox(component);
+    auto [pos2_x, pos2_y, size2] = to.get_hitbox(component2);
+    double vec_x = pos2_x - pos_x, vec_y = pos2_y - pos_y;
+    double vec_magnitude = sqrt(vec_x*vec_x + vec_y*vec_y);
+    return {vec_x / vec_magnitude, vec_y / vec_magnitude};
+}
+
+bool User::collide_with_user(User& user) {
+    if (distance(*this, user) > this->size + user.size) return false;
+
+    return this->foreach_component<bool>([&](Component &c, int i, bool acc) -> bool {
+        if (c.type != CELL && c.type != SPIKE) return acc;
+        double pos_x, pos_y;
+        int hitbox_size;
+        std::tie(pos_x, pos_y, hitbox_size) = this->get_hitbox(i);
+        return user.foreach_component<bool>([&](Component &c2, int j, bool acc2) -> bool {
+            if (c2.type != CELL && c2.type != SPIKE) return acc2;
+            auto [pos2_x, pos2_y, size2] = user.get_hitbox(j);
+            if (distance(pos_x, pos_y, pos2_x, pos2_y) > hitbox_size + size2) {
+                int layered_part = this->get_layered_part(i, pos2_x, pos2_y);
+                int layered_part2 = user.get_layered_part(j, pos_x, pos_y);
+                BODYPART_TYPE a = layered_part == -1 ? c.type : this->components[layered_part].type;
+                BODYPART_TYPE b = layered_part2 == -1 ? c2.type : this->components[layered_part2].type;
+
+                switch (a) {
+                    case BOUNCE:
+                        if (this->components[layered_part].is_working()) {
+                            switch (b) {
+                                case BOUNCE:
+                                    if (this->components[layered_part].is_working()) {
+                                        // TODO: tbd
+                                        break;
+                                    } // intentional fallthrough
+                                case CELL:
+                                case SHIELD:
+                                    user.bounce_back(*this, layered_part);
+                                    break;
+                                case SPIKE:
+                                    user.bounce_back(*this, layered_part, true);
+                                    this->components[layered_part].inflated = 0;
+                                    break;
+                                case NONE:
+                                    throw std::invalid_argument("bodypart with type NONE encountered during collision");
+                            }
+                            break;
+                        } // intentional fallthrough
+                    case CELL:
+                        switch (b) {
+                            case BOUNCE:
+                                if (user.components[layered_part2].is_working()) {
+                                    this->bounce_back(user, layered_part2);
+                                    break;
+                                } // intentional fallthrough
+                            case CELL:
+                            case SHIELD:
+                                this->transfer_momentum(i, user, j);
+                                user.transfer_momentum(j, *this, i);
+                                break;
+                            case SPIKE:
+                                if (this->damage(i, SPIKE_DMG)) {
+                                    user.kills++;
+                                }
+                                break;
+                            case NONE:
+                                throw std::invalid_argument("bodypart with type NONE encountered during collision");
+                        }
+                        break;
+                    case SPIKE:
+                        switch (b) {
+                            case BOUNCE:
+                                if (user.components[layered_part2].is_working()) {
+                                    this->bounce_back(user, layered_part2, true);
+                                    user.components[layered_part2].inflated = 0;
+                                    break;
+                                } // intentional fallthrough
+                            case CELL:
+                                if (user.damage(j, SPIKE_DMG)) {
+                                    this->kills++;
+                                }
+                                break;
+                            case SPIKE:
+                                if (user.damage(j, SPIKE_DMG)) {
+                                    this->kills++;
+                                }
+                                if (this->damage(i, SPIKE_DMG)) {
+                                    user.kills++;
+                                }
+                                break;
+                            case SHIELD:
+                                this->transfer_momentum(i, user, j);
+                                user.transfer_momentum(j, *this, i);
+                                break;
+                            case NONE:
+                                throw std::invalid_argument("bodypart with type NONE encountered during collision");
+                        }
+                        break;
+                    case SHIELD:
+                        switch (b) {
+                            case BOUNCE:
+                                if (user.components[layered_part2].is_working()) {
+                                    this->bounce_back(user, layered_part2);
+                                    break;
+                                } // intentional fallthrough
+                            case CELL:
+                            case SPIKE:
+                            case SHIELD:
+                                this->transfer_momentum(i, user, j);
+                                user.transfer_momentum(j, *this, i);
+                                break;
+                            case NONE:
+                                throw std::invalid_argument("bodypart with type NONE encountered during collision");
+                        }
+                        break;
+                    case NONE:
+                        throw std::invalid_argument("bodypart with type NONE encountered during collision");
+                }
+                return true;
+            }
+            return acc2;
+        }, acc);
+
+    }, false);
+}
+
+void User::bounce_back(User &bouncer, int bounce_component, bool popped) {
+    // we have an off-by-one error here on purpose.
+    // one of the faces _has_ to contain the bounce. If it gets to the 7th face and throws
+    // an exception due to the illegal array access something has already gone wrong
+    int face = 0;
+    for (; face <= 7; face++) {
+        if (bouncer.components[bouncer.components[bounce_component].body].faces[face] == bounce_component) break;
+    }
+    double x_magn = std::cos(FACE_TO_ANGLE[face]), y_magn = std::sin(FACE_TO_ANGLE[face]);
+    this->momentum_x += BOUNCE_MOMENTUM * (popped ? BOUNCE_POPPED_MULTIPLIER : 1) * x_magn;
+    this->momentum_y += BOUNCE_MOMENTUM * (popped ? BOUNCE_POPPED_MULTIPLIER : 1) * y_magn;
+    bouncer.momentum_x += BOUNCE_MOMENTUM_SELF * (popped ? BOUNCE_POPPED_MULTIPLIER : 1) * -x_magn;
+    bouncer.momentum_y += BOUNCE_MOMENTUM_SELF * (popped ? BOUNCE_POPPED_MULTIPLIER : 1) * -y_magn;
+}
+
+void User::transfer_momentum(int component, User &user, int other_component) {
+    auto [pos_x, pos_y, _] = get_hitbox(component);
+    auto [pos2_x, pos2_y, size2] = user.get_hitbox(other_component);
+    double vec_x = pos2_x - pos_x, vec_y = pos2_y - pos_y;
+    double vec_magnitude = sqrt(vec_x*vec_x + vec_y*vec_y);
+    double vec_x_norm = vec_x / vec_magnitude, vec_y_norm = vec_y / vec_magnitude;
+
+    if ((vec_x_norm < 0 && momentum_x < 0)
+    || (vec_x_norm >= 0 && momentum_x >= 0)) {
+        double amt_to_transfer = momentum_x * MOMENTUM_TRANSFER_ON_COLLISION * vec_x_norm;
+        user.momentum_x += amt_to_transfer;
+        this->momentum_x -= amt_to_transfer;
+    }
+    if ((vec_y_norm < 0 && momentum_y < 0)
+    || (vec_y_norm >= 0 && momentum_y >= 0)) {
+        double amt_to_transfer = momentum_y * MOMENTUM_TRANSFER_ON_COLLISION * vec_y_norm;
+        user.momentum_y += amt_to_transfer;
+        this->momentum_y -= amt_to_transfer;
+    }
+}
+
+int User::get_layered_part(int component, double to_x, double to_y) const {
+    if (this->components[component].type != CELL) return NONE;
+    auto [pos_x, pos_y, _] = this->get_hitbox(component);
+
+    double vec_x = to_x - pos_x, vec_y = to_y - pos_y;
+
+    double angle = std::atan2(vec_y, vec_x);
+    double local_angle = this->rotation + angle;
+
+    // this (implicit) cast is safe - after flooring we're guaranteed to have an integer number which should
+    // convert to int without issues
+    int offset = std::floor(local_angle * 3 / M_PI) + 3; // NOLINT(cppcoreguidelines-narrowing-conversions)
+    if (offset == 6) offset = 0;
+
+    return this->components[component].faces[offset];
+}
+
+bool User::collide_with_resource(Resource &res) {
+    if (res.amt <= 0) return false;
+    double resource_size = std::min((double) RESOURCE_SIZE_MAX, RESOURCE_SIZE_MIN + res.amt * RESOURCE_SIZE_STEP);
+    if (distance(this->x, this->y, res.x, res.y) > this->size + resource_size) return false;
+
+    return this->foreach_component<bool>([&](const Component &c, int i, bool acc) -> bool {
+        if (c.type != CELL && c.type != SPIKE) return acc;
+
+        auto [pos_x, pos_y, hitbox_size] = this->get_hitbox(i);
+        if (distance(pos_x, pos_y, res.x, res.y) > resource_size + hitbox_size) return acc;
+
+        int layered_component = this->get_layered_part(i, res.x, res.y);
+        if (layered_component != -1 && this->components[layered_component].type == SHIELD) return acc;
+
+        int amt = std::min(res.amt, MINING_RATE * (c.type == SPIKE ? SPIKE_MINING_MULTIPLIER : 1));
+        this->resources += amt;
+        res.amt -= amt;
+        return true;
+    }, false);
+}
+
+/**
+ * Returns an approximation of the user's size as measured by distance between root and component farthest from it.
+ * @return an overestimate (by no more than 2*INNER_CELL_RADIUS) of the distance between the root cell and the outermost
+ *         edge of the outermost bodypart
+ */
+double User::get_size() const {
+    return size;
+}
+
+void User::compute_size() {
+    this->size = this->foreach_component<double>([this](Component &c, double dist) -> double {
+        if (c.type != CELL) return dist;
+        auto [pos_x, pos_y] = rel_pos(this->x, this->y, std::get<0>(c.coords),
+                                      std::get<1>(c.coords), std::get<2>(c.coords));
+        double new_distance = distance(pos_x, pos_y, this->x, this->y);
+        return std::max(new_distance, dist);
+        }, 0.);
+}
+
+template<typename T> T User::foreach_component(const std::function<T(Component&, T)>& f, T init) {
+    return this->foreach_component<T>([&](Component&c, int i, T a) {
+        return f(c, a);
+    }, init);
+}
+void User::foreach_component(const std::function<void(Component&)>& f) const{
+    this->foreach_component([&](Component &c, int) {
+        f(c);
+    });
+}
+template<typename T> T User::foreach_component(const std::function<T(Component&, int, T)>& f, T init) {
+    T acc = init;
+    for (int i = 0; i < this->next_component; i++) {
+        acc = f(this->components[i], i, acc);
+    }
+    return acc;
+}
+void User::foreach_component(const std::function<void(Component&, int)>& f) const{
+    for (int i = 0; i < this->next_component; i++) {
+        f(this->components[i], i);
+    }
+}
+

--- a/engine/user.h
+++ b/engine/user.h
@@ -1,0 +1,69 @@
+#ifndef HEXARENA_BACKEND_USER_H
+#define HEXARENA_BACKEND_USER_H
+
+#include <vector>
+#include <set>
+
+#include "constants.h"
+#include "component.h"
+#include "utils.h"
+
+#define CELL_INNER_RADIUS 28
+
+class User {
+private:
+    double size;
+    /// Pointer to a function whose purpose is to drop the given amount of resources on the ground at the given position.
+    std::function<void(int, double, double)> drop;
+
+    void find_connected(int node, std::set<int> &set);
+
+    template<typename T> T foreach_component(const std::function<T(Component&, T)>&, T init);
+    void foreach_component(const std::function<void(Component&)>&) const;
+    template<typename T> T foreach_component(const std::function<T(Component&, int , T)>&, T init);
+    void foreach_component(const std::function<void(Component&, int)>&) const;
+
+    [[nodiscard]] std::tuple<double, double, int> get_hitbox(int component) const;
+    std::pair<double, double> get_direction_normalised(int component, User &to, int component2) const;
+    [[nodiscard]] int get_layered_part(int component, double to_x, double to_y) const;
+    void transfer_momentum(int component, User &user, int other_component);
+    void bounce_back(User &bouncer, int bounce_component, bool popped = false);
+
+    void compute_size();
+
+
+public:
+    int id;
+    double x;
+    double y;
+    double momentum_x;
+    double momentum_y;
+    double rotation;
+    Component* components;
+    int components_size;
+    int next_component;
+    int resources;
+    int kills;
+    bool destroyed;
+    bool moved;
+    bool rotated;
+    std::vector<void (*)(const User&)> observers;
+
+#if CHEATS_ENABLED
+    // char cheat_seq[20]; // TODO: cheats
+#endif
+
+
+    User(int id, double x, double y, std::function<void(int, double, double)> drop);
+    void tick_reset();
+    void tick_parts() const;
+    int grow(int part, int face, BODYPART_TYPE type);
+    bool damage(int part, int amt);
+    bool shrink(int part);
+    bool collide_with_user(User& user);
+    bool collide_with_resource(Resource &res);
+    double get_size() const;
+
+};
+
+#endif //HEXARENA_BACKEND_USER_H

--- a/engine/utils.h
+++ b/engine/utils.h
@@ -1,0 +1,16 @@
+#ifndef HEXARENA_BACKEND_UTILS_H
+#define HEXARENA_BACKEND_UTILS_H
+
+#include "user.h"
+
+struct Resource {
+    double x;
+    double y;
+    int amt;
+};
+
+double distance(double x1, double y1, double x2, double y2) {
+    return std::sqrt(std::pow(x1 - x2, 2) + std::pow(y1 - y2, 2));
+}
+
+#endif //HEXARENA_BACKEND_UTILS_H

--- a/main.cpp
+++ b/main.cpp
@@ -2,5 +2,4 @@
 
 int main(int argc, char** argv) {
     Engine engine;
-    engine.init();
 }


### PR DESCRIPTION
Differences compared to the js version:
 - engine is started/stopped in con/destructor rather than init/shutdown methods.
 - shields and bounces lose their hitbox - they are triggered when their parent is attacked from the appropriate angle
 - move() takes an angle rather than a direction. Moving is now only allowed once per tick.
 - movement and momentum have been rewritten, need rebalancing.
 - cheats are not yet available.
 - register() has been renamed to observe().
   - so have a few other methods but on those I added the old names too with the [[deprecated]] attribute. register is a reserved keyword in cpp so that one could not be copied.
 - One feature is missing pending discussion: player callbacks are not notified properly on player death.